### PR TITLE
Fix content of *toplevel-suites*

### DIFF
--- a/src/suite.lisp
+++ b/src/suite.lisp
@@ -57,7 +57,6 @@ Overrides any existing suite named NAME."
     (when description
       (setf (description suite) description))
     (when (and name
-               (null (name *suite*))
                (null parent-suite))
       (pushnew name *toplevel-suites*))
     (loop for i in (ensure-list parent-suite)


### PR DESCRIPTION
As soon as one _suite_ is defined, there's no mechanism to reset it.

So only the first one was recorded in _toplevel-suites_, making run-all-suites worthless.
